### PR TITLE
feat: add Docker support with dual Claude auth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+.idea/
+.task/
+.env
+*.out
+coverage.*
+coverage.html
+watson
+pr-reviewer

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# GitHub username whose review requests will be monitored
+GITHUB_REVIEWER_USERNAME=your-github-username
+
+# GitHub Personal Access Token — used by gh CLI inside the container
+# Minimum scopes: repo, read:org
+# Create one at: https://github.com/settings/tokens
+GH_TOKEN=your-github-token
+
+# ── Claude authentication (choose one) ───────────────────────────────────────
+
+# Option 1 — Long-lived OAuth token (recommended)
+# Uses your Pro/Max plan. No per-token billing.
+# Generate with: claude setup-token
+# Docs: docs/docker.md
+CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
+
+# Option 2 — Anthropic API key
+# Billed per token. No plan required.
+# Create one at: https://console.anthropic.com/settings/keys
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# How often (in minutes) to poll GitHub for pending PRs (default: 15)
+# POLL_INTERVAL_MINUTES=15
+
+# Claude model to use for reviews (default: claude-sonnet-4-20250514)
+# CLAUDE_MODEL=claude-sonnet-4-20250514
+
+# Base directory for temporary git clones (default: OS temp dir + /watson)
+# REPO_BASE_DIR=
+
+# SSH host alias defined in ~/.ssh/config for git cloning via SSH
+# Required only if you prefer SSH over HTTPS. Also uncomment the volume
+# in docker-compose.yml so the container can access your SSH keys.
+# GIT_SSH_HOST=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# ── Stage 1: build ───────────────────────────────────────────────────────────
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o watson ./cmd/
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+# git + curl + dependencies for gh and Node.js
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+      https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js LTS + Claude Code CLI
+# claude --print uses ANTHROPIC_API_KEY for non-interactive auth
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/watson /usr/local/bin/watson
+
+ENTRYPOINT ["watson"]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ task clean          # Remove binário e artefatos
 
 | Documento | Conteúdo |
 |-----------|----------|
+| [`docs/docker.md`](docs/docker.md) | Deploy com Docker: build, autenticação OAuth/API key, SSH |
 | [`docs/architecture.md`](docs/architecture.md) | Estrutura de pacotes, decisões técnicas, fluxo interno |
 | [`docs/configuration.md`](docs/configuration.md) | Referência completa de configuração e autenticação |
 | [`docs/development.md`](docs/development.md) | Build, testes, cobertura e convenções |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  watson:
+    build: .
+    restart: unless-stopped
+    env_file:
+      - .env
+
+    # Uncomment to enable SSH-based git cloning (required when GIT_SSH_HOST is set).
+    # Mount your host SSH config so the container can authenticate via the alias
+    # defined in ~/.ssh/config.
+    #
+    # volumes:
+    #   - ${HOME}/.ssh:/root/.ssh:ro

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,116 @@
+# Docker
+
+## Pré-requisitos
+
+- [Docker](https://docs.docker.com/get-docker/) com Compose V2 (`docker compose version`)
+- [GitHub CLI](https://cli.github.com/) instalado **localmente** para gerar o token OAuth (Opção 1)
+
+---
+
+## Quickstart
+
+```bash
+# 1. Copie e preencha as variáveis de ambiente
+cp .env.example .env
+
+# 2. Build da imagem
+docker compose build
+
+# 3. Suba o daemon
+docker compose up -d
+
+# 4. Acompanhe os logs
+docker compose logs -f
+```
+
+---
+
+## Autenticação do Claude Code
+
+O watson suporta duas formas de autenticar o Claude Code no container. Escolha a que melhor se encaixa no seu uso.
+
+---
+
+### Opção 1 — OAuth token de longa duração (recomendado)
+
+Usa o seu plano Pro/Max — sem cobrança por token.
+
+**Como gerar o token:**
+
+```bash
+claude setup-token
+```
+
+O comando exibe um token OAuth de longa duração. Copie-o e adicione ao `.env`:
+
+```env
+CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
+```
+
+O Claude Code detecta automaticamente a variável e usa o token para autenticar — sem login interativo, sem sessão para gerenciar.
+
+> **Renovação:** tokens gerados pelo `claude setup-token` têm duração estendida, mas podem expirar. Se o container começar a falhar com erro de autenticação, basta rodar `claude setup-token` novamente e atualizar o `.env`.
+
+---
+
+### Opção 2 — Anthropic API key
+
+Cobrança por token consumido. Não requer plano.
+
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Gere sua chave em [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys).
+
+> Use esta opção para ambientes de CI/CD ou quando não houver um plano Pro/Max disponível.
+
+---
+
+## Autenticação do GitHub CLI
+
+O `gh` CLI autentica via variável de ambiente `GH_TOKEN`. Gere um **Personal Access Token** (clássico ou fine-grained) em [github.com/settings/tokens](https://github.com/settings/tokens).
+
+**Escopos mínimos necessários:**
+
+| Escopo | Motivo |
+|--------|--------|
+| `repo` | Listar PRs, ler diffs, postar comentários |
+| `read:org` | Buscar PRs em repositórios de organizações |
+
+```env
+GH_TOKEN=your-github-token
+```
+
+---
+
+## Clonagem via SSH (opcional)
+
+Por padrão o watson clona repositórios via HTTPS. Se preferir SSH (ex.: múltiplas contas GitHub ou GitHub Enterprise), defina `GIT_SSH_HOST` e monte suas chaves SSH no container.
+
+No `.env`:
+
+```env
+GIT_SSH_HOST=my-ssh-alias
+```
+
+No `docker-compose.yml`, descomente o volume:
+
+```yaml
+volumes:
+  - ${HOME}/.ssh:/root/.ssh:ro
+```
+
+O alias deve estar definido em `~/.ssh/config` na sua máquina host. Veja [`docs/configuration.md`](configuration.md) para detalhes.
+
+---
+
+## Comandos úteis
+
+```bash
+docker compose build          # Reconstrói a imagem
+docker compose up -d          # Sobe o daemon em background
+docker compose logs -f        # Acompanha os logs em tempo real
+docker compose down           # Para e remove o container
+docker compose restart        # Reinicia o container
+```


### PR DESCRIPTION
## Summary

- **Dockerfile**: multi-stage build — `golang:1.25-alpine` para build e `debian:bookworm-slim` como runtime. Instala `git`, `gh` CLI, Node.js LTS e Claude Code CLI.
- **docker-compose.yml**: serviço único com `env_file` e volume SSH opcional para `GIT_SSH_HOST`.
- **.env.example**: documenta as duas formas de autenticação do Claude Code (ver abaixo).
- **.dockerignore**: exclui artefatos de build, IDE e secrets.
- **docs/docker.md**: guia completo de deploy com Docker.
- **README.md**: adiciona `docs/docker.md` na tabela de documentação.

## Autenticação do Claude Code

Duas opções documentadas — o dev escolhe:

| Método | Variável | Cobrança |
|--------|----------|----------|
| OAuth token de longa duração | `CLAUDE_CODE_OAUTH_TOKEN` | Plano Pro/Max |
| Anthropic API key | `ANTHROPIC_API_KEY` | Pay-per-token |

O OAuth token é gerado com `claude setup-token` e não requer login interativo no container.

## Test plan

- [x] `docker compose build` conclui sem erros
- [x] `docker compose up` sobe o daemon com `CLAUDE_CODE_OAUTH_TOKEN`
- [x] `docker compose up` sobe o daemon com `ANTHROPIC_API_KEY`
- [x] Logs de startup exibem `watson started`

🤖 Generated with [Claude Code](https://claude.com/claude-code)