### PR TITLE
feat(reviewer): mention-triggered re-review via @username

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,17 @@ CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
 # Can be any name/email — this identity is never pushed anywhere.
 # GIT_USER_NAME=Your Name
 # GIT_USER_EMAIL=you@example.com
+
+# ── Mention re-review ─────────────────────────────────────────────────────────
+
+# How long (in hours) a reviewed PR stays in the in-memory cache.
+# Watson checks for @mentions only on cached PRs. After this period the entry
+# is evicted — lower values reduce GitHub API usage, higher values allow Watson
+# to respond to mentions on older PRs. (default: 168 = 7 days)
+# REVIEW_TTL_HOURS=168
+
+# Minimum time (in minutes) between two consecutive reviews of the same PR.
+# Mentions received within this window are ignored, preventing comment spam
+# when a PR is mentioned multiple times in quick succession.
+# Recommended: set to a value >= POLL_INTERVAL_MINUTES. (default: 60)
+# RE_REVIEW_COOLDOWN_MINUTES=60

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
 # ── Required ──────────────────────────────────────────────────────────────────
 
-# GitHub username whose review requests will be monitored
-GITHUB_REVIEWER_USERNAME=your-github-username
-
 # GitHub Personal Access Token (classic) — used by gh CLI inside the container.
 # IMPORTANT: use a classic PAT, NOT a fine-grained token.
 # Fine-grained tokens do not support the GraphQL addComment mutation

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Pressione `Ctrl+C` para encerrar o daemon graciosamente.
 | `CLAUDE_MODEL` | Não | `claude-sonnet-4-20250514` | Modelo Claude utilizado |
 | `REPO_BASE_DIR` | Não | `os.TempDir()/watson` | Diretório para clones temporários |
 | `GIT_SSH_HOST` | Não | — | Alias SSH para autenticação customizada |
+| `REVIEW_TTL_HOURS` | Não | `168` (7 dias) | Tempo máximo que um PR revisado permanece no cache. Após esse período, o PR é removido da memória e Watson deixa de verificar menções nele. Controla o consumo de memória e o volume de chamadas à API do GitHub por tick (uma chamada por PR em cache). |
+| `RE_REVIEW_COOLDOWN_MINUTES` | Não | `60` | Intervalo mínimo entre dois reviews consecutivos do mesmo PR. Menções recebidas dentro desse período são ignoradas, evitando spam de comentários em caso de múltiplas menções rápidas. Recomenda-se um valor ≥ `POLL_INTERVAL_MINUTES`. |
 
 ¹ Obrigatório no Docker. No uso local o `gh auth login` é suficiente.
 ² Escolha um dos dois. `CLAUDE_CODE_OAUTH_TOKEN` usa seu plano Pro/Max sem cobrança por token.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ docker compose up -d
 
 ```bash
 # Produção — posta comentários nos PRs
-GITHUB_REVIEWER_USERNAME=seu-usuario ./watson
+GH_TOKEN=... ./watson
 
 # Dry-run — imprime reviews no stdout, sem escrever no GitHub
-GITHUB_REVIEWER_USERNAME=seu-usuario ./watson --dry-run
+GH_TOKEN=... ./watson --dry-run
 
 # Poll a cada 5 minutos
-GITHUB_REVIEWER_USERNAME=seu-usuario POLL_INTERVAL_MINUTES=5 ./watson
+GH_TOKEN=... POLL_INTERVAL_MINUTES=5 ./watson
 ```
 
 Pressione `Ctrl+C` para encerrar o daemon graciosamente.
@@ -90,7 +90,6 @@ Pressione `Ctrl+C` para encerrar o daemon graciosamente.
 
 | Variável | Obrigatória | Padrão | Descrição |
 |----------|:-----------:|--------|-----------|
-| `GITHUB_REVIEWER_USERNAME` | Sim | — | Seu usuário GitHub |
 | `GH_TOKEN` | Sim¹ | — | Classic PAT do GitHub (escopo `repo`) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Sim² | — | OAuth token de longa duração (`claude setup-token`) |
 | `ANTHROPIC_API_KEY` | Sim² | — | API key da Anthropic (alternativa ao OAuth token) |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,10 +30,17 @@ func main() {
 	cfg.DryRun = *dryRun
 
 	executor := ghpkg.NewShellExecutor()
-	rev := reviewer.NewReviewer(cfg, executor, logger)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+
+	username, err := ghpkg.ResolveCurrentUser(ctx, executor)
+	if err != nil {
+		log.Fatalf("resolve GitHub user: %v", err)
+	}
+	cfg.GitHubReviewerUsername = username
+
+	rev := reviewer.NewReviewer(cfg, executor, logger)
 
 	interval := time.Duration(cfg.PollIntervalMinutes) * time.Minute
 	ticker := time.NewTicker(interval)

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,30 @@ type Config struct {
 	// Loaded from GIT_SSH_HOST.
 	GitSSHHost string
 
+	// ReviewTTLHours controls how long a reviewed PR stays in the in-memory cache.
+	// After this period, the entry is removed: Watson will no longer check for
+	// @mentions on that PR, and if it is still open and review is requested again,
+	// it will be treated as a new PR.
+	//
+	// This value directly bounds memory usage and the number of GitHub API calls
+	// made per tick for mention checking (one call per cached PR per tick).
+	// Lower values reduce API usage; higher values allow Watson to respond to
+	// mentions on older PRs.
+	//
+	// Default: 168 (7 days). Configurable via REVIEW_TTL_HOURS.
+	ReviewTTLHours int
+
+	// ReReviewCooldownMinutes is the minimum time that must elapse between two
+	// consecutive reviews of the same PR (first-time or re-review). Mentions that
+	// arrive within this window are ignored until the cooldown expires.
+	//
+	// This prevents comment spam when a PR receives multiple @mentions in rapid
+	// succession. Set to a value >= POLL_INTERVAL_MINUTES to ensure at most one
+	// re-review per mention burst.
+	//
+	// Default: 60 minutes. Configurable via RE_REVIEW_COOLDOWN_MINUTES.
+	ReReviewCooldownMinutes int
+
 	// DryRun is set by the --dry-run CLI flag (not an env var).
 	// When true, reviews are printed to stdout instead of posted on GitHub.
 	DryRun bool
@@ -57,12 +81,32 @@ func Load() (*Config, error) {
 	baseDir := getenv("REPO_BASE_DIR", filepath.Join(os.TempDir(), "watson"))
 	sshHost := os.Getenv("GIT_SSH_HOST")
 
+	reviewTTL := 168
+	if raw := os.Getenv("REVIEW_TTL_HOURS"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			return nil, fmt.Errorf("REVIEW_TTL_HOURS must be a positive integer, got %q", raw)
+		}
+		reviewTTL = v
+	}
+
+	cooldown := 60
+	if raw := os.Getenv("RE_REVIEW_COOLDOWN_MINUTES"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			return nil, fmt.Errorf("RE_REVIEW_COOLDOWN_MINUTES must be a positive integer, got %q", raw)
+		}
+		cooldown = v
+	}
+
 	return &Config{
-		GitHubReviewerUsername: username,
-		PollIntervalMinutes:    pollInterval,
-		ClaudeModel:            model,
-		RepoBaseDir:            baseDir,
-		GitSSHHost:             sshHost,
+		GitHubReviewerUsername:  username,
+		PollIntervalMinutes:     pollInterval,
+		ClaudeModel:             model,
+		RepoBaseDir:             baseDir,
+		GitSSHHost:              sshHost,
+		ReviewTTLHours:          reviewTTL,
+		ReReviewCooldownMinutes: cooldown,
 	}, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,9 @@ import (
 
 // Config holds all runtime configuration for the watson daemon.
 type Config struct {
-	// GitHubReviewerUsername is the GitHub username whose review requests are polled.
-	// Required — loaded from GITHUB_REVIEWER_USERNAME.
+	// GitHubReviewerUsername is the GitHub login of the authenticated user.
+	// Resolved once on startup via "gh api user" and stored here for the
+	// lifetime of the daemon. Not configurable via env var.
 	GitHubReviewerUsername string
 
 	// PollIntervalMinutes controls how often GitHub is polled.
@@ -62,12 +63,9 @@ type Config struct {
 
 // Load reads configuration from environment variables.
 // Returns an error if any required variable is missing or malformed.
+// GitHubReviewerUsername is not set here — call ResolveCurrentUser after
+// creating the executor and assign the result to cfg.GitHubReviewerUsername.
 func Load() (*Config, error) {
-	username := os.Getenv("GITHUB_REVIEWER_USERNAME")
-	if username == "" {
-		return nil, fmt.Errorf("GITHUB_REVIEWER_USERNAME is required")
-	}
-
 	pollInterval := 15
 	if raw := os.Getenv("POLL_INTERVAL_MINUTES"); raw != "" {
 		v, err := strconv.Atoi(raw)
@@ -100,7 +98,6 @@ func Load() (*Config, error) {
 	}
 
 	return &Config{
-		GitHubReviewerUsername:  username,
 		PollIntervalMinutes:     pollInterval,
 		ClaudeModel:             model,
 		RepoBaseDir:             baseDir,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,36 @@ ssh -T git@<alias>
 
 ---
 
+### `REVIEW_TTL_HOURS`
+
+Tempo em horas que um PR revisado permanece no cache em memória. Após esse período, a entrada é removida: Watson para de verificar menções nesse PR e, se ele ainda estiver aberto com review solicitado, será tratado como novo na próxima vez.
+
+Esse valor controla diretamente o consumo de memória e o volume de chamadas à API do GitHub por tick — uma chamada `gh pr view` por PR em cache para verificação de menções.
+
+- **Padrão:** `168` (7 dias)
+- **Restrição:** deve ser um inteiro positivo
+
+```bash
+REVIEW_TTL_HOURS=48 ./watson   # mantém cache por 2 dias
+```
+
+---
+
+### `RE_REVIEW_COOLDOWN_MINUTES`
+
+Intervalo mínimo em minutos entre dois reviews consecutivos do mesmo PR (primeiro review ou re-review). Menções recebidas dentro dessa janela são ignoradas até o cooldown expirar.
+
+Isso evita spam de comentários quando um PR recebe múltiplas menções em sequência rápida. Recomenda-se configurar um valor maior ou igual a `POLL_INTERVAL_MINUTES`.
+
+- **Padrão:** `60`
+- **Restrição:** deve ser um inteiro positivo
+
+```bash
+RE_REVIEW_COOLDOWN_MINUTES=30 ./watson
+```
+
+---
+
 ## Flag de linha de comando
 
 ### `--dry-run`
@@ -126,6 +156,8 @@ POLL_INTERVAL_MINUTES=10 \
 CLAUDE_MODEL=claude-sonnet-4-20250514 \
 REPO_BASE_DIR=/tmp/reviews \
 GIT_SSH_HOST=meu-alias-ssh \
+REVIEW_TTL_HOURS=168 \
+RE_REVIEW_COOLDOWN_MINUTES=60 \
 ./watson
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,16 +2,6 @@
 
 ## Variáveis de ambiente
 
-### `GITHUB_REVIEWER_USERNAME` (obrigatória)
-
-Usuário GitHub cujos review requests serão monitorados. O daemon busca PRs onde este usuário foi solicitado como reviewer.
-
-```bash
-GITHUB_REVIEWER_USERNAME=seu-usuario ./watson
-```
-
----
-
 ### `POLL_INTERVAL_MINUTES`
 
 Intervalo em minutos entre cada poll do GitHub.
@@ -151,7 +141,6 @@ Em dry-run, todas as etapas são executadas normalmente (clone, diff, Claude, de
 ## Exemplo completo
 
 ```bash
-GITHUB_REVIEWER_USERNAME=seu-usuario \
 POLL_INTERVAL_MINUTES=10 \
 CLAUDE_MODEL=claude-sonnet-4-20250514 \
 REPO_BASE_DIR=/tmp/reviews \

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -161,7 +161,7 @@ func FindMentionAfter(comments []Comment, username string, after time.Time) *Com
 // field returned by gh pr view --json comments). reaction must be a valid
 // ReactionContent enum value (e.g. "EYES", "THUMBS_UP", "HEART").
 func ReactToComment(ctx context.Context, exec Executor, commentID string, reaction string) error {
-	const mutation = `mutation($id:ID!,$r:ReactionContent!){addReaction(input:{subjectId:$id,content:$r}){reaction{content}}}`
+	const mutation = `mutation($subjectId:ID!,$content:ReactionContent!){addReaction(input:{subjectId:$subjectId,content:$content}){reaction{content}}}`
 	_, err := exec.Run(ctx,
 		"gh", "api", "graphql",
 		"-f", "query="+mutation,

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -99,6 +99,7 @@ type CommentAuthor struct {
 
 // Comment represents a single issue-level comment on a pull request.
 type Comment struct {
+	ID        string        `json:"id"` // GraphQL node ID (e.g. "IC_kwDO...")
 	Author    CommentAuthor `json:"author"`
 	Body      string        `json:"body"`
 	CreatedAt time.Time     `json:"createdAt"`
@@ -151,6 +152,24 @@ func FindMentionAfter(comments []Comment, username string, after time.Time) *Com
 		if c.CreatedAt.After(after) && strings.Contains(c.Body, mention) && c.Author.Login != username {
 			return c
 		}
+	}
+	return nil
+}
+
+// ReactToComment adds an emoji reaction to the given comment using the GitHub
+// GraphQL API. commentID must be the GraphQL node ID of the comment (the "id"
+// field returned by gh pr view --json comments). reaction must be a valid
+// ReactionContent enum value (e.g. "EYES", "THUMBS_UP", "HEART").
+func ReactToComment(ctx context.Context, exec Executor, commentID string, reaction string) error {
+	const mutation = `mutation($id:ID!,$r:ReactionContent!){addReaction(input:{subjectId:$id,content:$r}){reaction{content}}}`
+	_, err := exec.Run(ctx,
+		"gh", "api", "graphql",
+		"-f", "query="+mutation,
+		"-f", "subjectId="+commentID,
+		"-f", "content="+reaction,
+	)
+	if err != nil {
+		return fmt.Errorf("react to comment: %w", err)
 	}
 	return nil
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -53,6 +53,22 @@ func (pr PullRequest) CloneURL(sshHost string) string {
 	return pr.RepoURL()
 }
 
+// ResolveCurrentUser returns the GitHub login of the authenticated user by
+// querying the GitHub API. Call once on startup and store the result in Config.
+//
+//	gh api user --jq .login
+func ResolveCurrentUser(ctx context.Context, exec Executor) (string, error) {
+	out, err := exec.Run(ctx, "gh", "api", "user", "--jq", ".login")
+	if err != nil {
+		return "", fmt.Errorf("gh api user: %w", err)
+	}
+	username := strings.TrimSpace(string(out))
+	if username == "" {
+		return "", fmt.Errorf("gh api user returned empty login")
+	}
+	return username, nil
+}
+
 // ListReviewRequestedPRs fetches all open PRs where the authenticated user is a
 // requested reviewer across all repositories.
 //

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 )
 
 // Repository holds the repo metadata returned by gh search prs.
@@ -80,6 +82,54 @@ func ListPendingPRs(ctx context.Context, exec Executor, processed *sync.Map) ([]
 		}
 	}
 	return pending, nil
+}
+
+// CommentAuthor holds the author of a PR comment.
+type CommentAuthor struct {
+	Login string `json:"login"`
+}
+
+// Comment represents a single issue-level comment on a pull request.
+type Comment struct {
+	Author    CommentAuthor `json:"author"`
+	Body      string        `json:"body"`
+	CreatedAt time.Time     `json:"createdAt"`
+}
+
+// FetchPRComments returns the issue-level comments for the given PR.
+//
+//	gh pr view <prNumber> --repo <nameWithOwner> --json comments
+func FetchPRComments(ctx context.Context, exec Executor, prNumber int, nameWithOwner string) ([]Comment, error) {
+	out, err := exec.Run(ctx,
+		"gh", "pr", "view", fmt.Sprintf("%d", prNumber),
+		"--repo", nameWithOwner,
+		"--json", "comments",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view #%d comments: %w", prNumber, err)
+	}
+
+	var result struct {
+		Comments []Comment `json:"comments"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parse comments for PR #%d: %w", prNumber, err)
+	}
+	return result.Comments, nil
+}
+
+// FindMentionAfter returns the first comment that mentions @username posted after
+// the given cutoff time, ignoring comments authored by username itself (to prevent
+// self-triggering). Returns nil if no such comment exists.
+func FindMentionAfter(comments []Comment, username string, after time.Time) *Comment {
+	mention := "@" + username
+	for i := range comments {
+		c := &comments[i]
+		if c.CreatedAt.After(after) && strings.Contains(c.Body, mention) && c.Author.Login != username {
+			return c
+		}
+	}
+	return nil
 }
 
 // PRRefs holds the head branch, base branch, and commit list for a PR.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -54,12 +53,12 @@ func (pr PullRequest) CloneURL(sshHost string) string {
 	return pr.RepoURL()
 }
 
-// ListPendingPRs fetches all open PRs where the authenticated user is a
-// requested reviewer across all repositories, filtering out PR numbers
-// already present in the processed sync.Map.
+// ListReviewRequestedPRs fetches all open PRs where the authenticated user is a
+// requested reviewer across all repositories.
 //
 // Uses gh search prs so it works from any directory without a local git context.
-func ListPendingPRs(ctx context.Context, exec Executor, processed *sync.Map) ([]PullRequest, error) {
+// Filtering (e.g. skipping already-processed PRs) is the caller's responsibility.
+func ListReviewRequestedPRs(ctx context.Context, exec Executor) ([]PullRequest, error) {
 	out, err := exec.Run(ctx,
 		"gh", "search", "prs",
 		"--review-requested=@me",
@@ -74,14 +73,7 @@ func ListPendingPRs(ctx context.Context, exec Executor, processed *sync.Map) ([]
 	if err := json.Unmarshal(out, &all); err != nil {
 		return nil, fmt.Errorf("parse gh search prs output: %w", err)
 	}
-
-	pending := make([]PullRequest, 0, len(all))
-	for _, pr := range all {
-		if _, done := processed.Load(pr.Number); !done {
-			pending = append(pending, pr)
-		}
-	}
-	return pending, nil
+	return all, nil
 }
 
 // CommentAuthor holds the author of a PR comment.
@@ -116,6 +108,21 @@ func FetchPRComments(ctx context.Context, exec Executor, prNumber int, nameWithO
 		return nil, fmt.Errorf("parse comments for PR #%d: %w", prNumber, err)
 	}
 	return result.Comments, nil
+}
+
+// FindLastWatsonComment returns the most recent comment authored by username,
+// or nil if the user has no comments on the PR.
+func FindLastWatsonComment(comments []Comment, username string) *Comment {
+	var last *Comment
+	for i := range comments {
+		c := &comments[i]
+		if c.Author.Login == username {
+			if last == nil || c.CreatedAt.After(last.CreatedAt) {
+				last = c
+			}
+		}
+	}
+	return last
 }
 
 // FindMentionAfter returns the first comment that mentions @username posted after

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestListPendingPRs_ReturnsParsedPRs(t *testing.T) {
@@ -77,6 +78,109 @@ func TestPullRequest_CloneURL_SSH(t *testing.T) {
 	pr := PullRequest{Repository: Repository{NameWithOwner: "org/repo"}}
 	if got := pr.CloneURL("github-snk"); got != "git@github-snk:org/repo.git" {
 		t.Errorf("expected SSH URL with alias, got %q", got)
+	}
+}
+
+func TestFetchPRComments(t *testing.T) {
+	raw := `{"comments":[
+		{"author":{"login":"alice"},"body":"looks good @watson","createdAt":"2026-03-17T10:00:00Z"},
+		{"author":{"login":"bob"},"body":"nice work","createdAt":"2026-03-17T11:00:00Z"}
+	]}`
+	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte(raw)}}}
+
+	comments, err := FetchPRComments(context.Background(), exec, 42, "org/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(comments))
+	}
+	if comments[0].Author.Login != "alice" {
+		t.Errorf("expected alice, got %q", comments[0].Author.Login)
+	}
+	if comments[1].Body != "nice work" {
+		t.Errorf("unexpected body: %q", comments[1].Body)
+	}
+}
+
+func TestFetchPRComments_Error(t *testing.T) {
+	exec := &MockExecutor{Responses: []MockResponse{{Err: errors.New("gh: not found")}}}
+
+	_, err := FetchPRComments(context.Background(), exec, 1, "org/repo")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestFindMentionAfter_ReturnsMention(t *testing.T) {
+	cutoff := mustParseTime("2026-03-17T09:00:00Z")
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "alice"}, Body: "@watson please re-review", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+	}
+
+	got := FindMentionAfter(comments, "watson", cutoff)
+	if got == nil {
+		t.Fatal("expected mention, got nil")
+	}
+	if got.Author.Login != "alice" {
+		t.Errorf("expected alice, got %q", got.Author.Login)
+	}
+}
+
+func TestFindMentionAfter_NilWhenNone(t *testing.T) {
+	cutoff := mustParseTime("2026-03-17T09:00:00Z")
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "alice"}, Body: "no mention here", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+	}
+
+	if got := FindMentionAfter(comments, "watson", cutoff); got != nil {
+		t.Errorf("expected nil, got comment from %q", got.Author.Login)
+	}
+}
+
+func TestFindMentionAfter_IgnoresBeforeCutoff(t *testing.T) {
+	cutoff := mustParseTime("2026-03-17T12:00:00Z")
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "alice"}, Body: "@watson re-review", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+	}
+
+	if got := FindMentionAfter(comments, "watson", cutoff); got != nil {
+		t.Error("expected nil for comment before cutoff")
+	}
+}
+
+func TestFindMentionAfter_IgnoresOwnComments(t *testing.T) {
+	cutoff := mustParseTime("2026-03-17T09:00:00Z")
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "watson"}, Body: "@watson this is my own comment", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+	}
+
+	if got := FindMentionAfter(comments, "watson", cutoff); got != nil {
+		t.Error("expected nil: should not self-trigger")
+	}
+}
+
+func TestFindMentionAfter_ReturnsFirstMatch(t *testing.T) {
+	cutoff := mustParseTime("2026-03-17T09:00:00Z")
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "alice"}, Body: "@watson first", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+		{Author: CommentAuthor{Login: "bob"}, Body: "@watson second", CreatedAt: mustParseTime("2026-03-17T11:00:00Z")},
+	}
+
+	got := FindMentionAfter(comments, "watson", cutoff)
+	if got == nil {
+		t.Fatal("expected mention, got nil")
+	}
+	if got.Author.Login != "alice" {
+		t.Errorf("expected first match from alice, got %q", got.Author.Login)
 	}
 }
 

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -73,6 +73,36 @@ func TestPullRequest_CloneURL_SSH(t *testing.T) {
 	}
 }
 
+func TestResolveCurrentUser(t *testing.T) {
+	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte("watsonrc\n")}}}
+
+	got, err := ResolveCurrentUser(context.Background(), exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "watsonrc" {
+		t.Errorf("expected %q, got %q", "watsonrc", got)
+	}
+}
+
+func TestResolveCurrentUser_EmptyOutput(t *testing.T) {
+	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte("\n")}}}
+
+	_, err := ResolveCurrentUser(context.Background(), exec)
+	if err == nil {
+		t.Fatal("expected error for empty login, got nil")
+	}
+}
+
+func TestResolveCurrentUser_GhError(t *testing.T) {
+	exec := &MockExecutor{Responses: []MockResponse{{Err: errors.New("gh: auth required")}}}
+
+	_, err := ResolveCurrentUser(context.Background(), exec)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 func TestFindLastWatsonComment_ReturnsLatest(t *testing.T) {
 	comments := []Comment{
 		{Author: CommentAuthor{Login: "watson"}, Body: "first review", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -238,6 +238,38 @@ func TestFindMentionAfter_ReturnsFirstMatch(t *testing.T) {
 	}
 }
 
+func TestReactToComment(t *testing.T) {
+	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte(`{"data":{}}`)}}}
+
+	if err := ReactToComment(context.Background(), exec, "IC_abc123", "EYES"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(exec.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(exec.Calls))
+	}
+	call := exec.Calls[0]
+	if call.Name != "gh" {
+		t.Errorf("expected gh, got %q", call.Name)
+	}
+	found := false
+	for _, arg := range call.Args {
+		if arg == "subjectId=IC_abc123" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected subjectId=IC_abc123 in args: %v", call.Args)
+	}
+}
+
+func TestReactToComment_Error(t *testing.T) {
+	exec := &MockExecutor{Responses: []MockResponse{{Err: errors.New("gh: forbidden")}}}
+
+	if err := ReactToComment(context.Background(), exec, "IC_abc123", "EYES"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 func TestFetchPRRefs(t *testing.T) {
 	raw := `{"headRefName":"feat/my-branch","baseRefName":"master"}`
 	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte(raw)}}}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -3,19 +3,18 @@ package github
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 )
 
-func TestListPendingPRs_ReturnsParsedPRs(t *testing.T) {
+func TestListReviewRequestedPRs_ReturnsParsedPRs(t *testing.T) {
 	raw := `[
 		{"number":1,"title":"feat: A","body":"body A","repository":{"nameWithOwner":"org/repo"}},
 		{"number":2,"title":"feat: B","body":"","repository":{"nameWithOwner":"org/repo"}}
 	]`
 	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte(raw)}}}
 
-	prs, err := ListPendingPRs(context.Background(), exec, &sync.Map{})
+	prs, err := ListReviewRequestedPRs(context.Background(), exec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -27,7 +26,7 @@ func TestListPendingPRs_ReturnsParsedPRs(t *testing.T) {
 	}
 }
 
-func TestListPendingPRs_FiltersProcessed(t *testing.T) {
+func TestListReviewRequestedPRs_ReturnsAll(t *testing.T) {
 	raw := `[
 		{"number":1,"title":"feat: A","body":"","repository":{"nameWithOwner":"org/repo"}},
 		{"number":2,"title":"feat: B","body":"","repository":{"nameWithOwner":"org/repo"}},
@@ -35,26 +34,19 @@ func TestListPendingPRs_FiltersProcessed(t *testing.T) {
 	]`
 	exec := &MockExecutor{Responses: []MockResponse{{Out: []byte(raw)}}}
 
-	processed := &sync.Map{}
-	processed.Store(1, struct{}{})
-	processed.Store(3, struct{}{})
-
-	prs, err := ListPendingPRs(context.Background(), exec, processed)
+	prs, err := ListReviewRequestedPRs(context.Background(), exec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(prs) != 1 {
-		t.Fatalf("expected 1 PR, got %d", len(prs))
-	}
-	if prs[0].Number != 2 {
-		t.Errorf("expected PR #2, got #%d", prs[0].Number)
+	if len(prs) != 3 {
+		t.Fatalf("expected all 3 PRs, got %d", len(prs))
 	}
 }
 
-func TestListPendingPRs_GhError(t *testing.T) {
+func TestListReviewRequestedPRs_GhError(t *testing.T) {
 	exec := &MockExecutor{Responses: []MockResponse{{Err: errors.New("gh: not found")}}}
 
-	_, err := ListPendingPRs(context.Background(), exec, &sync.Map{})
+	_, err := ListReviewRequestedPRs(context.Background(), exec)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -78,6 +70,38 @@ func TestPullRequest_CloneURL_SSH(t *testing.T) {
 	pr := PullRequest{Repository: Repository{NameWithOwner: "org/repo"}}
 	if got := pr.CloneURL("github-snk"); got != "git@github-snk:org/repo.git" {
 		t.Errorf("expected SSH URL with alias, got %q", got)
+	}
+}
+
+func TestFindLastWatsonComment_ReturnsLatest(t *testing.T) {
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "watson"}, Body: "first review", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+		{Author: CommentAuthor{Login: "alice"}, Body: "nice", CreatedAt: mustParseTime("2026-03-17T11:00:00Z")},
+		{Author: CommentAuthor{Login: "watson"}, Body: "second review", CreatedAt: mustParseTime("2026-03-17T12:00:00Z")},
+	}
+
+	got := FindLastWatsonComment(comments, "watson")
+	if got == nil {
+		t.Fatal("expected comment, got nil")
+	}
+	if got.Body != "second review" {
+		t.Errorf("expected latest comment, got %q", got.Body)
+	}
+}
+
+func TestFindLastWatsonComment_NilWhenNone(t *testing.T) {
+	comments := []Comment{
+		{Author: CommentAuthor{Login: "alice"}, Body: "LGTM", CreatedAt: mustParseTime("2026-03-17T10:00:00Z")},
+	}
+
+	if got := FindLastWatsonComment(comments, "watson"); got != nil {
+		t.Errorf("expected nil, got comment from %q", got.Author.Login)
+	}
+}
+
+func TestFindLastWatsonComment_EmptySlice(t *testing.T) {
+	if got := FindLastWatsonComment(nil, "watson"); got != nil {
+		t.Error("expected nil for empty comments")
 	}
 }
 

--- a/internal/reviewer/prompt.go
+++ b/internal/reviewer/prompt.go
@@ -14,6 +14,10 @@ type PromptContext struct {
 	Diff  string
 	Stats string // output of "git diff --stat"
 	Note  string // files excluded by sanitization, or truncation warning
+	// Re-review fields: populated only for mention-triggered reviews.
+	IsReReview     bool
+	PreviousReview string // Watson's last review text
+	MentionComment string // the comment that triggered the re-review
 }
 
 // BuildPrompt assembles the review prompt sent to the Claude CLI.
@@ -33,6 +37,9 @@ func BuildPrompt(ctx PromptContext) string {
 	var sb strings.Builder
 
 	sb.WriteString("Você é um engenheiro de software sênior fazendo um code review. Responda em português de forma direta e técnica.\n\n")
+	if ctx.IsReReview {
+		sb.WriteString("**Esta é uma revisão atualizada.** Considere o review anterior e o comentário que o solicitou ao elaborar sua análise.\n\n")
+	}
 	fmt.Fprintf(&sb, "## Pull Request #%d: %s\n", pr.Number, pr.Title)
 	fmt.Fprintf(&sb, "**Repositório:** %s\n", pr.Repository.NameWithOwner)
 
@@ -69,6 +76,17 @@ func BuildPrompt(ctx PromptContext) string {
 	sb.WriteString("```diff\n")
 	sb.WriteString(diff)
 	sb.WriteString("\n```\n\n")
+
+	if ctx.IsReReview {
+		sb.WriteString("### Contexto do re-review\n")
+		sb.WriteString("Comentário que solicitou o re-review:\n\n")
+		for _, line := range strings.Split(ctx.MentionComment, "\n") {
+			fmt.Fprintf(&sb, "> %s\n", line)
+		}
+		sb.WriteString("\nReview anterior para referência:\n\n")
+		sb.WriteString(ctx.PreviousReview)
+		sb.WriteString("\n\n")
+	}
 
 	sb.WriteString("Responda usando exatamente este template, sem adicionar ou remover seções:\n\n")
 	sb.WriteString("## Resumo\n")

--- a/internal/reviewer/prompt_test.go
+++ b/internal/reviewer/prompt_test.go
@@ -131,6 +131,41 @@ func TestBuildPrompt_ContainsReviewTemplate(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_ReReview_ContainsContext(t *testing.T) {
+	pr := github.PullRequest{Number: 10, Title: "fix: auth"}
+	ctx := PromptContext{
+		PR:             pr,
+		Diff:           "diff",
+		IsReReview:     true,
+		PreviousReview: "## Resumo\nAlterou autenticação.",
+		MentionComment: "@watson o bug foi corrigido, por favor revise novamente",
+	}
+	prompt := BuildPrompt(ctx)
+
+	for _, want := range []string{
+		"revisão atualizada",
+		"@watson o bug foi corrigido",
+		"## Resumo\nAlterou autenticação.",
+		"Contexto do re-review",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+func TestBuildPrompt_ReReview_False_NoContext(t *testing.T) {
+	pr := github.PullRequest{Number: 10, Title: "fix: auth"}
+	prompt := BuildPrompt(PromptContext{PR: pr, Diff: "diff"})
+
+	if strings.Contains(prompt, "revisão atualizada") {
+		t.Error("non-re-review prompt should not contain re-review header")
+	}
+	if strings.Contains(prompt, "Contexto do re-review") {
+		t.Error("non-re-review prompt should not contain re-review section")
+	}
+}
+
 func TestBuildPrompt_ContainsNote(t *testing.T) {
 	pr := github.PullRequest{Number: 9, Title: "chore: deps"}
 	prompt := BuildPrompt(PromptContext{PR: pr, Diff: "diff", Note: "Arquivos ignorados: go.sum"})

--- a/internal/reviewer/review.go
+++ b/internal/reviewer/review.go
@@ -46,23 +46,59 @@ func NewReviewer(cfg *config.Config, exec ghpkg.Executor, logger *slog.Logger) *
 	}
 }
 
-// ProcessPendingPRs is called on every ticker tick. It cleans up stale cache
-// entries, lists pending PRs, launches a goroutine for each one, then checks
-// reviewed PRs for new @mentions. Per-PR errors are logged but do not abort the loop.
+// ProcessPendingPRs is called on every ticker tick. It:
+//  1. Cleans up stale cache entries
+//  2. Fetches all open review-requested PRs
+//  3. For uncached PRs, checks if Watson has a previous comment:
+//     - If yes: recovers state into the cache so processMentionedPRs can detect
+//       any pending @mention (handles the restart/redeploy case)
+//     - If no: queues for first-time review
+//  4. Reviews first-time PRs in parallel
+//  5. Checks all cached PRs (including newly recovered) for @mentions
 func (r *Reviewer) ProcessPendingPRs(ctx context.Context) error {
 	r.cleanupStaleRecords()
 
-	prs, err := ghpkg.ListPendingPRs(ctx, r.executor, r.processed)
+	prs, err := ghpkg.ListReviewRequestedPRs(ctx, r.executor)
 	if err != nil {
 		return fmt.Errorf("list PRs: %w", err)
 	}
 
-	if len(prs) == 0 {
-		r.logger.Info("no pending PRs found")
+	var firstTimePRs []ghpkg.PullRequest
+	for _, pr := range prs {
+		if _, cached := r.processed.Load(pr.Number); cached {
+			continue // already in cache; processMentionedPRs handles it
+		}
+
+		// Uncached PR: check if Watson has reviewed it before (e.g. previous session).
+		comments, err := ghpkg.FetchPRComments(ctx, r.executor, pr.Number, pr.Repository.NameWithOwner)
+		if err != nil {
+			r.logger.Warn("could not fetch comments, treating PR as new", "pr", pr.Number, "err", err)
+			firstTimePRs = append(firstTimePRs, pr)
+			continue
+		}
+
+		last := ghpkg.FindLastWatsonComment(comments, r.cfg.GitHubReviewerUsername)
+		if last == nil {
+			firstTimePRs = append(firstTimePRs, pr)
+			continue
+		}
+
+		// Previous review found: recover state so processMentionedPRs can detect
+		// any mention that arrived since that review (including across restarts).
+		r.logger.Debug("recovering previously-reviewed PR into cache", "pr", pr.Number)
+		r.processed.Store(pr.Number, reviewRecord{
+			PR:         pr,
+			Review:     last.Body,
+			ReviewedAt: last.CreatedAt,
+		})
+	}
+
+	if len(firstTimePRs) == 0 {
+		r.logger.Info("no new PRs to review")
 	} else {
-		r.logger.Info("processing PRs", "count", len(prs))
+		r.logger.Info("processing new PRs", "count", len(firstTimePRs))
 		var wg sync.WaitGroup
-		for _, pr := range prs {
+		for _, pr := range firstTimePRs {
 			wg.Add(1)
 			go func(pr ghpkg.PullRequest) {
 				defer wg.Done()

--- a/internal/reviewer/review.go
+++ b/internal/reviewer/review.go
@@ -46,10 +46,12 @@ func NewReviewer(cfg *config.Config, exec ghpkg.Executor, logger *slog.Logger) *
 	}
 }
 
-// ProcessPendingPRs is called on every ticker tick. It lists pending PRs,
-// launches a goroutine for each one, then checks reviewed PRs for new @mentions.
-// Per-PR errors are logged but do not abort the loop.
+// ProcessPendingPRs is called on every ticker tick. It cleans up stale cache
+// entries, lists pending PRs, launches a goroutine for each one, then checks
+// reviewed PRs for new @mentions. Per-PR errors are logged but do not abort the loop.
 func (r *Reviewer) ProcessPendingPRs(ctx context.Context) error {
+	r.cleanupStaleRecords()
+
 	prs, err := ghpkg.ListPendingPRs(ctx, r.executor, r.processed)
 	if err != nil {
 		return fmt.Errorf("list PRs: %w", err)
@@ -76,14 +78,42 @@ func (r *Reviewer) ProcessPendingPRs(ctx context.Context) error {
 	return nil
 }
 
+// cleanupStaleRecords removes cache entries whose ReviewedAt timestamp has
+// exceeded ReviewTTLHours. This bounds both the memory usage of the processed
+// map and the number of GitHub API calls made per tick for mention checking.
+func (r *Reviewer) cleanupStaleRecords() {
+	ttl := time.Duration(r.cfg.ReviewTTLHours) * time.Hour
+	r.processed.Range(func(key, value any) bool {
+		if rec, ok := value.(reviewRecord); ok && time.Since(rec.ReviewedAt) > ttl {
+			r.processed.Delete(key)
+		}
+		return true
+	})
+}
+
 // processMentionedPRs checks all previously-reviewed PRs for new @mentions.
 // When a mention is found after the last review, a re-review is triggered with
 // the updated diff, the previous review text, and the triggering comment as context.
+//
+// Two checks gate each entry before any API call is made:
+//   - TTL: skip if the entry is older than ReviewTTLHours (will be removed by cleanup)
+//   - Cooldown: skip if the last review happened within ReReviewCooldownMinutes
 func (r *Reviewer) processMentionedPRs(ctx context.Context) {
+	ttl := time.Duration(r.cfg.ReviewTTLHours) * time.Hour
+	cooldown := time.Duration(r.cfg.ReReviewCooldownMinutes) * time.Minute
+
 	r.processed.Range(func(key, value any) bool {
 		rec, ok := value.(reviewRecord)
 		if !ok {
 			return true
+		}
+
+		age := time.Since(rec.ReviewedAt)
+		if age > ttl {
+			return true // stale; will be removed by cleanupStaleRecords on next tick
+		}
+		if age < cooldown {
+			return true // too recent; ignore mentions until cooldown expires
 		}
 
 		comments, err := ghpkg.FetchPRComments(ctx, r.executor, rec.PR.Number, rec.PR.Repository.NameWithOwner)

--- a/internal/reviewer/review.go
+++ b/internal/reviewer/review.go
@@ -164,6 +164,11 @@ func (r *Reviewer) processMentionedPRs(ctx context.Context) {
 		}
 
 		r.logger.Info("mention detected, triggering re-review", "pr", rec.PR.Number, "author", mention.Author.Login)
+
+		if err := ghpkg.ReactToComment(ctx, r.executor, mention.ID, "EYES"); err != nil {
+			r.logger.Warn("failed to react to mention comment", "pr", rec.PR.Number, "err", err)
+		}
+
 		if err := r.reviewPRInternal(ctx, rec.PR, &reReviewContext{
 			PreviousReview: rec.Review,
 			MentionComment: mention.Body,

--- a/internal/reviewer/review.go
+++ b/internal/reviewer/review.go
@@ -7,11 +7,25 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/meopedevts/watson/config"
 	"github.com/meopedevts/watson/internal/git"
 	ghpkg "github.com/meopedevts/watson/internal/github"
 )
+
+// reviewRecord stores state for a PR that has been reviewed at least once.
+type reviewRecord struct {
+	PR         ghpkg.PullRequest
+	Review     string    // the review text Watson posted
+	ReviewedAt time.Time // when it was posted
+}
+
+// reReviewContext carries the context for a mention-triggered re-review.
+type reReviewContext struct {
+	PreviousReview string
+	MentionComment string
+}
 
 // Reviewer orchestrates the full PR review pipeline.
 // All external dependencies are injected for testability.
@@ -32,9 +46,9 @@ func NewReviewer(cfg *config.Config, exec ghpkg.Executor, logger *slog.Logger) *
 	}
 }
 
-// ProcessPendingPRs is called on every ticker tick. It lists pending PRs
-// and launches a goroutine for each one. Per-PR errors are logged but
-// do not abort the loop.
+// ProcessPendingPRs is called on every ticker tick. It lists pending PRs,
+// launches a goroutine for each one, then checks reviewed PRs for new @mentions.
+// Per-PR errors are logged but do not abort the loop.
 func (r *Reviewer) ProcessPendingPRs(ctx context.Context) error {
 	prs, err := ghpkg.ListPendingPRs(ctx, r.executor, r.processed)
 	if err != nil {
@@ -43,33 +57,74 @@ func (r *Reviewer) ProcessPendingPRs(ctx context.Context) error {
 
 	if len(prs) == 0 {
 		r.logger.Info("no pending PRs found")
-		return nil
+	} else {
+		r.logger.Info("processing PRs", "count", len(prs))
+		var wg sync.WaitGroup
+		for _, pr := range prs {
+			wg.Add(1)
+			go func(pr ghpkg.PullRequest) {
+				defer wg.Done()
+				if err := r.ReviewPR(ctx, pr); err != nil {
+					r.logger.Error("review failed", "pr", pr.Number, "title", pr.Title, "err", err)
+				}
+			}(pr)
+		}
+		wg.Wait()
 	}
 
-	r.logger.Info("processing PRs", "count", len(prs))
-
-	var wg sync.WaitGroup
-	for _, pr := range prs {
-		wg.Add(1)
-		go func(pr ghpkg.PullRequest) {
-			defer wg.Done()
-			if err := r.ReviewPR(ctx, pr); err != nil {
-				r.logger.Error("review failed", "pr", pr.Number, "title", pr.Title, "err", err)
-			}
-		}(pr)
-	}
-	wg.Wait()
+	r.processMentionedPRs(ctx)
 	return nil
 }
 
-// ReviewPR runs the full review pipeline for a single PR:
+// processMentionedPRs checks all previously-reviewed PRs for new @mentions.
+// When a mention is found after the last review, a re-review is triggered with
+// the updated diff, the previous review text, and the triggering comment as context.
+func (r *Reviewer) processMentionedPRs(ctx context.Context) {
+	r.processed.Range(func(key, value any) bool {
+		rec, ok := value.(reviewRecord)
+		if !ok {
+			return true
+		}
+
+		comments, err := ghpkg.FetchPRComments(ctx, r.executor, rec.PR.Number, rec.PR.Repository.NameWithOwner)
+		if err != nil {
+			r.logger.Warn("failed to fetch comments for mention check", "pr", rec.PR.Number, "err", err)
+			return true
+		}
+
+		mention := ghpkg.FindMentionAfter(comments, r.cfg.GitHubReviewerUsername, rec.ReviewedAt)
+		if mention == nil {
+			return true
+		}
+
+		r.logger.Info("mention detected, triggering re-review", "pr", rec.PR.Number, "author", mention.Author.Login)
+		if err := r.reviewPRInternal(ctx, rec.PR, &reReviewContext{
+			PreviousReview: rec.Review,
+			MentionComment: mention.Body,
+		}); err != nil {
+			r.logger.Error("re-review failed", "pr", rec.PR.Number, "err", err)
+		}
+
+		return true
+	})
+}
+
+// ReviewPR runs the full review pipeline for a single PR (first-time review).
+func (r *Reviewer) ReviewPR(ctx context.Context, pr ghpkg.PullRequest) error {
+	return r.reviewPRInternal(ctx, pr, nil)
+}
+
+// reviewPRInternal is the shared review implementation used for both first-time
+// reviews and mention-triggered re-reviews. When reCtx is non-nil the prompt
+// includes the previous review text and the triggering comment.
+//
 //  1. Clone repository to a temp directory (cleaned up via defer)
-//  2. Compute diff against origin/main
+//  2. Compute diff against origin/<base>
 //  3. Build prompt and call Claude
 //  4. Check for merge conflicts; append warning if found
 //  5. Post comment (or print if dry-run)
-//  6. Mark PR as processed — ONLY on full success
-func (r *Reviewer) ReviewPR(ctx context.Context, pr ghpkg.PullRequest) error {
+//  6. Update processed record — ONLY on full success
+func (r *Reviewer) reviewPRInternal(ctx context.Context, pr ghpkg.PullRequest, reCtx *reReviewContext) error {
 	r.logger.Info("starting review", "pr", pr.Number, "title", pr.Title, "repo", pr.Repository.NameWithOwner)
 
 	refs, err := ghpkg.FetchPRRefs(ctx, r.executor, pr.Number, pr.Repository.NameWithOwner)
@@ -92,15 +147,20 @@ func (r *Reviewer) ReviewPR(ctx context.Context, pr ghpkg.PullRequest) error {
 		return fmt.Errorf("PR #%d diff: %w", pr.Number, err)
 	}
 
-	prompt := BuildPrompt(PromptContext{
+	promptCtx := PromptContext{
 		PR:    pr,
 		Refs:  refs,
 		Diff:  diffResult.Diff,
 		Stats: diffResult.Stats,
 		Note:  diffResult.Note,
-	})
+	}
+	if reCtx != nil {
+		promptCtx.IsReReview = true
+		promptCtx.PreviousReview = reCtx.PreviousReview
+		promptCtx.MentionComment = reCtx.MentionComment
+	}
 
-	review, err := r.runClaude(ctx, prompt)
+	review, err := r.runClaude(ctx, BuildPrompt(promptCtx))
 	if err != nil {
 		return fmt.Errorf("PR #%d claude review: %w", pr.Number, err)
 	}
@@ -117,7 +177,11 @@ func (r *Reviewer) ReviewPR(ctx context.Context, pr ghpkg.PullRequest) error {
 		return fmt.Errorf("PR #%d post comment: %w", pr.Number, err)
 	}
 
-	r.processed.Store(pr.Number, struct{}{})
+	r.processed.Store(pr.Number, reviewRecord{
+		PR:         pr,
+		Review:     review,
+		ReviewedAt: time.Now(),
+	})
 	r.logger.Info("review completed", "pr", pr.Number)
 	return nil
 }

--- a/internal/reviewer/review_test.go
+++ b/internal/reviewer/review_test.go
@@ -61,6 +61,11 @@ func TestCleanupStaleRecords_KeepsAllFresh(t *testing.T) {
 	}
 }
 
+func TestCleanupStaleRecords_EmptyMap(t *testing.T) {
+	r := newTestReviewer(168, 60)
+	r.cleanupStaleRecords() // must not panic on empty map
+}
+
 func TestProcessMentionedPRs_SkipsWithinCooldown(t *testing.T) {
 	// MockExecutor in the github package is only accessible from that package.
 	// We verify the cooldown by checking that no executor call is made:

--- a/internal/reviewer/review_test.go
+++ b/internal/reviewer/review_test.go
@@ -1,0 +1,103 @@
+package reviewer
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meopedevts/watson/config"
+	ghpkg "github.com/meopedevts/watson/internal/github"
+)
+
+func newTestReviewer(reviewTTLHours, cooldownMinutes int) *Reviewer {
+	return &Reviewer{
+		cfg: &config.Config{
+			GitHubReviewerUsername:  "watson",
+			ReviewTTLHours:          reviewTTLHours,
+			ReReviewCooldownMinutes: cooldownMinutes,
+		},
+		processed: &sync.Map{},
+		logger:    slog.Default(),
+	}
+}
+
+func storeRecord(r *Reviewer, prNumber int, reviewedAt time.Time) {
+	r.processed.Store(prNumber, reviewRecord{
+		PR:         ghpkg.PullRequest{Number: prNumber, Repository: ghpkg.Repository{NameWithOwner: "org/repo"}},
+		Review:     "previous review",
+		ReviewedAt: reviewedAt,
+	})
+}
+
+func TestCleanupStaleRecords_RemovesExpired(t *testing.T) {
+	r := newTestReviewer(1, 60) // TTL = 1 hour
+
+	storeRecord(r, 1, time.Now().Add(-2*time.Hour)) // expired
+	storeRecord(r, 2, time.Now().Add(-30*time.Minute)) // still fresh
+
+	r.cleanupStaleRecords()
+
+	if _, ok := r.processed.Load(1); ok {
+		t.Error("PR #1 should have been removed (expired)")
+	}
+	if _, ok := r.processed.Load(2); !ok {
+		t.Error("PR #2 should still be in cache (not expired)")
+	}
+}
+
+func TestCleanupStaleRecords_KeepsAllFresh(t *testing.T) {
+	r := newTestReviewer(168, 60)
+
+	storeRecord(r, 10, time.Now().Add(-1*time.Hour))
+	storeRecord(r, 11, time.Now().Add(-24*time.Hour))
+
+	r.cleanupStaleRecords()
+
+	for _, prNum := range []int{10, 11} {
+		if _, ok := r.processed.Load(prNum); !ok {
+			t.Errorf("PR #%d should still be in cache", prNum)
+		}
+	}
+}
+
+func TestProcessMentionedPRs_SkipsWithinCooldown(t *testing.T) {
+	// MockExecutor in the github package is only accessible from that package.
+	// We verify the cooldown by checking that no executor call is made:
+	// if FetchPRComments were called, it would panic with a nil executor.
+	r := &Reviewer{
+		cfg: &config.Config{
+			GitHubReviewerUsername:  "watson",
+			ReviewTTLHours:          168,
+			ReReviewCooldownMinutes: 60,
+		},
+		processed: &sync.Map{},
+		logger:    slog.Default(),
+		executor:  nil, // nil executor — any API call would panic
+	}
+
+	// Reviewed 5 minutes ago — within the 60-min cooldown
+	storeRecord(r, 1, time.Now().Add(-5*time.Minute))
+
+	// Should not panic (no API call made)
+	r.processMentionedPRs(t.Context())
+}
+
+func TestProcessMentionedPRs_SkipsExpiredTTL(t *testing.T) {
+	r := &Reviewer{
+		cfg: &config.Config{
+			GitHubReviewerUsername:  "watson",
+			ReviewTTLHours:          1,
+			ReReviewCooldownMinutes: 1,
+		},
+		processed: &sync.Map{},
+		logger:    slog.Default(),
+		executor:  nil, // nil executor — any API call would panic
+	}
+
+	// Reviewed 2 hours ago — past the 1-hour TTL
+	storeRecord(r, 1, time.Now().Add(-2*time.Hour))
+
+	// Should not panic (skipped due to TTL)
+	r.processMentionedPRs(t.Context())
+}


### PR DESCRIPTION
## Summary

- Adiciona suporte a re-review disparado por menção: quando alguém escreve `@<GITHUB_REVIEWER_USERNAME>` em um comentário de um PR já revisado, Watson detecta no próximo tick e posta uma nova revisão
- O re-review inclui o diff atualizado (novos commits desde o último review), o review anterior e o comentário que disparou — permitindo passar instruções específicas (ex: `@watson a parte de auth foi refatorada, foca nela`)
- Comentários do próprio Watson são ignorados para evitar loop infinito de re-reviews

## Mudanças

- `internal/github/pr.go` — `FetchPRComments()` e `FindMentionAfter()` para buscar e detectar menções
- `internal/reviewer/review.go` — `reviewRecord` substitui `struct{}` no mapa de processados (armazena PR, review e timestamp); `processMentionedPRs()` itera o mapa a cada tick; `reviewPRInternal()` implementação compartilhada com contexto de re-review opcional
- `internal/reviewer/prompt.go` — campos `IsReReview`, `PreviousReview`, `MentionComment` no `PromptContext`; seção "Contexto do re-review" inserida no prompt quando aplicável

## Test plan

- [x] `task check` passa (go vet + go test ./...)
- [x] Testar no próprio PR: mencionar `@<username>` nos comentários e verificar se Watson posta re-review no próximo tick
- [x] Verificar que o re-review inclui o review anterior como contexto
- [x] Verificar que múltiplas menções antes do re-review não causam reviews duplicados (só a primeira é processada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)